### PR TITLE
remove unused dependency: babel-preset-react-hmre

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
-    "babel-preset-react-hmre": "^1.1.1",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.7.2",
     "chai": "^3.5.0",


### PR DESCRIPTION
Remove unused `babel-preset-react-hmre` if we switch to `react-hot-loader@3.0.0` 
